### PR TITLE
feat: convert create match screen to compose

### DIFF
--- a/app/src/main/kotlin/io/github/raghavsatyadev/scus/compose/support/navigation/AppNavHost.kt
+++ b/app/src/main/kotlin/io/github/raghavsatyadev/scus/compose/support/navigation/AppNavHost.kt
@@ -66,7 +66,12 @@ fun AppNavHost(viewModel: MainViewModel) {
           )
         }
         entry<AppRoutes.Login> { LoginScreen { viewModel.changeLoginState() } }
-        entry<AppRoutes.CreateMatch> { CreateMatchScreen(matchRecord = it.matchRecord) }
+        entry<AppRoutes.CreateMatch> {
+          CreateMatchScreen(
+            matchRecord = it.matchRecord,
+            onMatchCreated = { backStack.removeLastOrNull() },
+          )
+        }
         entry<AppRoutes.MatchRecord> { key -> }
       },
   )

--- a/app/src/main/kotlin/io/github/raghavsatyadev/scus/compose/ui/create_match/CreateMatchScreen.kt
+++ b/app/src/main/kotlin/io/github/raghavsatyadev/scus/compose/ui/create_match/CreateMatchScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.material3.rememberTimePickerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -51,6 +52,7 @@ import androidx.constraintlayout.compose.Dimension
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import io.github.raghavsatyadev.scus.R
 import io.github.raghavsatyadev.support.compose.components.AppToolBar
+import io.github.raghavsatyadev.support.compose.components.ErrorDialog
 import io.github.raghavsatyadev.support.compose.components.DarkPreview
 import io.github.raghavsatyadev.support.compose.components.LightPreview
 import io.github.raghavsatyadev.support.compose.theme.AppTheme
@@ -59,6 +61,7 @@ import io.github.raghavsatyadev.support.extensions.DateExtensions.toZoneEpochMil
 import io.github.raghavsatyadev.support.extensions.DateExtensions.toZoneLocalDate
 import io.github.raghavsatyadev.support.extensions.DateExtensions.toZoneLocalDateTime
 import io.github.raghavsatyadev.support.models.db.match_record.MatchRecord
+import io.github.raghavsatyadev.support.models.essential.UiState
 import java.time.LocalDateTime
 import java.time.LocalTime
 import java.util.Calendar
@@ -67,6 +70,7 @@ import java.util.Calendar
 fun CreateMatchScreen(
   matchRecord: MatchRecord? = null,
   viewModel: CreateMatchScreenViewModel = hiltViewModel(),
+  onMatchCreated: (MatchRecord) -> Unit = {},
 ) {
 
   LaunchedEffect(matchRecord) {
@@ -76,6 +80,8 @@ fun CreateMatchScreen(
       viewModel.resetMatchRecord()
     }
   }
+
+  HandleCreateMatchEvents(viewModel, onMatchCreated)
 
   var showDateTimeDialogs by remember { mutableStateOf(false) }
 
@@ -109,6 +115,33 @@ fun CreateMatchScreen(
       )
     },
   )
+}
+
+@Composable
+private fun HandleCreateMatchEvents(
+  viewModel: CreateMatchScreenViewModel,
+  onMatchCreated: (MatchRecord) -> Unit,
+) {
+  val createMatchState by viewModel.createMatchRecordEvent.collectAsState()
+
+  when (val state = createMatchState) {
+    is UiState.Initial -> {}
+
+    is UiState.Error -> {
+      ErrorDialog(
+        errorCode = state.error.errorCode,
+        errorMessage = state.error.exception?.message
+          ?: stringResource(state.error.errorCode.warning),
+      ) {
+        viewModel.createMatchEventConsumed()
+      }
+    }
+
+    is UiState.Success -> {
+      onMatchCreated(state.data)
+      viewModel.createMatchEventConsumed()
+    }
+  }
 }
 
 @Composable

--- a/app/src/main/kotlin/io/github/raghavsatyadev/scus/compose/ui/create_match/CreateMatchScreenViewModel.kt
+++ b/app/src/main/kotlin/io/github/raghavsatyadev/scus/compose/ui/create_match/CreateMatchScreenViewModel.kt
@@ -2,13 +2,21 @@ package io.github.raghavsatyadev.scus.compose.ui.create_match
 
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import io.github.raghavsatyadev.support.R as Rs
 import io.github.raghavsatyadev.support.compose.components.UiStateManager
 import io.github.raghavsatyadev.support.compose.core.CoreScreenViewModel
 import io.github.raghavsatyadev.support.compose.google.FireStoreUtil
 import io.github.raghavsatyadev.support.compose.google.FirebaseAuthUtil
+import io.github.raghavsatyadev.support.core.CoreApp
 import io.github.raghavsatyadev.support.models.db.match_record.MatchRecord
 import io.github.raghavsatyadev.support.models.db.match_record.MatchRecordComposeDataUtil
+import io.github.raghavsatyadev.support.models.db.match_record.TeamDetail
+import io.github.raghavsatyadev.support.models.essential.CustomError
+import io.github.raghavsatyadev.support.models.essential.ErrorCode
+import io.github.raghavsatyadev.support.models.essential.UiState
+import java.util.Date
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -22,6 +30,9 @@ constructor(
   uiStateManager: UiStateManager,
 ) : CoreScreenViewModel(uiStateManager) {
   private val _matchRecordFlow = MutableStateFlow<MatchRecord?>(null)
+  private val _createMatchRecordEvent = MutableStateFlow<UiState<MatchRecord>>(UiState.Initial)
+
+  val createMatchRecordEvent = _createMatchRecordEvent.asStateFlow()
 
   fun setMatchRecord(matchRecord: MatchRecord) {
     viewModelScope.launch { _matchRecordFlow.emit(matchRecord) }
@@ -39,5 +50,58 @@ constructor(
     selectedIndexToss: Int,
     selectedIndexBat: Int,
     matchLocation: String,
-  ) {}
+  ) {
+    executeWithLoader {
+      try {
+        validateMatchDetails(matchLocation, inningOver, team1Name, team2Name)
+        val currentUserId = authUtil.currentUserId
+        val matchRecord =
+          MatchRecord(
+            location = matchLocation,
+            startDateTime = matchDateTime,
+            ballsPerInning = inningOver.toInt() * 6,
+            team1Detail = TeamDetail(teamName = team1Name),
+            team2Detail = TeamDetail(teamName = team2Name),
+            didTeam1WonToss = selectedIndexToss == 0,
+            isTeam1BattingFirst = selectedIndexBat == 0,
+            localUpdateDateTime = Date(),
+            serverUpdateDateTime = Date(),
+            matchAdminID = currentUserId!!,
+          )
+
+        val record = fireStoreUtil.createMatchRecord(matchRecord)
+        _createMatchRecordEvent.emit(UiState.Success(record))
+      } catch (e: Exception) {
+        _createMatchRecordEvent.emit(
+          UiState.Error(CustomError(ErrorCode.UNKNOWN_ERROR, e))
+        )
+      }
+    }
+  }
+
+  private fun validateMatchDetails(
+    matchLocation: String,
+    inningOver: String,
+    team1Name: String,
+    team2Name: String,
+  ) {
+    val context = CoreApp.instance
+    val currentUserId = authUtil.currentUserId
+    when {
+      currentUserId.isNullOrEmpty() ->
+        throw Exception(context.getString(Rs.string.warning_please_login))
+      matchLocation.isEmpty() ->
+        throw Exception(context.getString(Rs.string.warning_match_location))
+      inningOver.isEmpty() ->
+        throw Exception(context.getString(Rs.string.warning_overs))
+      team1Name.isEmpty() ->
+        throw Exception(context.getString(Rs.string.warning_team_1_name))
+      team2Name.isEmpty() ->
+        throw Exception(context.getString(Rs.string.warning_team_2_name))
+    }
+  }
+
+  fun createMatchEventConsumed() {
+    _createMatchRecordEvent.value = UiState.Initial
+  }
 }


### PR DESCRIPTION
## Summary
- implement Compose-based create match logic
- handle match creation events and validation in `CreateMatchScreen`
- integrate navigation callback when a match is created

## Testing
- `gradle test` *(fails: Minimum supported Gradle version is 9.0.0. Current version is 8.14.3)*

------
https://chatgpt.com/codex/tasks/task_e_68ab375b02f883258f718838d7f2dcac