### PR TITLE
Add Compose match record and complete screens

### DIFF
--- a/app/src/main/kotlin/io/github/raghavsatyadev/scus/compose/support/models/MatchRecordProperties.kt
+++ b/app/src/main/kotlin/io/github/raghavsatyadev/scus/compose/support/models/MatchRecordProperties.kt
@@ -1,0 +1,57 @@
+package io.github.raghavsatyadev.scus.compose.support.models
+
+import androidx.annotation.Keep
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.stringResource
+import io.github.raghavsatyadev.scus.R
+
+@Keep
+data class MatchRecordProperties(
+  val won: String,
+  val lost: String,
+  val draw: String,
+  val inProgress: String,
+  val lostColor: Color,
+  val winColor: Color,
+  val drawColor: Color,
+  val inProgressColor: Color,
+) {
+  companion object {
+    @Composable
+    fun rememberMatchRecordProperties(): MatchRecordProperties {
+      val won: String = stringResource(R.string.won)
+      val lost: String = stringResource(R.string.lost)
+      val draw: String = stringResource(R.string.draw)
+      val inProgress: String = stringResource(R.string.in_progress)
+      val lostColor = colorResource(android.R.color.holo_red_dark)
+      val winColor = colorResource(android.R.color.holo_green_dark)
+      val drawColor = colorResource(android.R.color.holo_blue_dark)
+      val inProgressColor = MaterialTheme.colorScheme.inverseSurface
+      return remember(
+        won,
+        lost,
+        draw,
+        inProgress,
+        lostColor,
+        winColor,
+        drawColor,
+        inProgressColor,
+      ) {
+        MatchRecordProperties(
+          won = won,
+          lost = lost,
+          draw = draw,
+          inProgress = inProgress,
+          lostColor = lostColor,
+          winColor = winColor,
+          drawColor = drawColor,
+          inProgressColor = inProgressColor,
+        )
+      }
+    }
+  }
+}

--- a/app/src/main/kotlin/io/github/raghavsatyadev/scus/compose/support/navigation/AppNavHost.kt
+++ b/app/src/main/kotlin/io/github/raghavsatyadev/scus/compose/support/navigation/AppNavHost.kt
@@ -14,6 +14,8 @@ import androidx.navigation3.ui.NavDisplay
 import io.github.raghavsatyadev.scus.compose.ui.create_match.CreateMatchScreen
 import io.github.raghavsatyadev.scus.compose.ui.dashboard.DashboardScreen
 import io.github.raghavsatyadev.scus.compose.ui.main.MainViewModel
+import io.github.raghavsatyadev.scus.compose.ui.match_complete.MatchCompleteScreen
+import io.github.raghavsatyadev.scus.compose.ui.match_record.MatchRecordScreen
 import io.github.raghavsatyadev.scus.compose.ui.user.LoginScreen
 import io.github.raghavsatyadev.support.compose.extesions.NavigationExtensions.replaceAll
 
@@ -72,7 +74,23 @@ fun AppNavHost(viewModel: MainViewModel) {
             onMatchCreated = { backStack.removeLastOrNull() },
           )
         }
-        entry<AppRoutes.MatchRecord> { key -> }
+        entry<AppRoutes.MatchRecord> { key ->
+          MatchRecordScreen(
+            matchId = key.matchId,
+            matchRecord = key.matchRecord,
+            onBack = { backStack.removeLastOrNull() },
+            onMatchCompleted = {
+              backStack.removeLastOrNull()
+              backStack.add(AppRoutes.MatchComplete(matchId = key.matchId))
+            },
+          )
+        }
+        entry<AppRoutes.MatchComplete> { key ->
+          MatchCompleteScreen(
+            matchId = key.matchId,
+            onBack = { backStack.removeLastOrNull() },
+          )
+        }
       },
   )
 }

--- a/app/src/main/kotlin/io/github/raghavsatyadev/scus/compose/support/navigation/AppRoutes.kt
+++ b/app/src/main/kotlin/io/github/raghavsatyadev/scus/compose/support/navigation/AppRoutes.kt
@@ -21,4 +21,8 @@ object AppRoutes {
     val matchId: String,
     val matchRecord: io.github.raghavsatyadev.support.models.db.match_record.MatchRecord,
   ) : NavKey
+
+  @Keep
+  @Serializable
+  data class MatchComplete(val matchId: String) : NavKey
 }

--- a/app/src/main/kotlin/io/github/raghavsatyadev/scus/compose/ui/create_match/CreateMatchScreen.kt
+++ b/app/src/main/kotlin/io/github/raghavsatyadev/scus/compose/ui/create_match/CreateMatchScreen.kt
@@ -124,21 +124,22 @@ private fun HandleCreateMatchEvents(
 ) {
   val createMatchState by viewModel.createMatchRecordEvent.collectAsState()
 
-  when (val state = createMatchState) {
-    is UiState.Initial -> {}
-
-    is UiState.Error -> {
-      ErrorDialog(
-        errorCode = state.error.errorCode,
-        errorMessage = state.error.exception?.message
-          ?: stringResource(state.error.errorCode.warning),
-      ) {
-        viewModel.createMatchEventConsumed()
-      }
+  if (createMatchState is UiState.Error) {
+    val state = createMatchState as UiState.Error
+    ErrorDialog(
+      errorCode = state.error.errorCode,
+      errorMessage = state.error.exception?.message
+        ?: stringResource(state.error.errorCode.warning),
+    ) {
+      viewModel.createMatchEventConsumed()
     }
+  }
 
-    is UiState.Success -> {
-      onMatchCreated(state.data)
+  val matchRecord = (createMatchState as? UiState.Success)?.data
+
+  LaunchedEffect(matchRecord) {
+    matchRecord?.let {
+      onMatchCreated(it)
       viewModel.createMatchEventConsumed()
     }
   }

--- a/app/src/main/kotlin/io/github/raghavsatyadev/scus/compose/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/kotlin/io/github/raghavsatyadev/scus/compose/ui/dashboard/DashboardScreen.kt
@@ -2,7 +2,6 @@
 
 package io.github.raghavsatyadev.scus.compose.ui.dashboard
 
-import androidx.annotation.Keep
 import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
@@ -23,10 +22,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -34,6 +30,7 @@ import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.constraintlayout.compose.Dimension
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import io.github.raghavsatyadev.scus.R
+import io.github.raghavsatyadev.scus.compose.support.models.MatchRecordProperties
 import io.github.raghavsatyadev.support.compose.components.AdUI
 import io.github.raghavsatyadev.support.compose.components.AppToolBar
 import io.github.raghavsatyadev.support.compose.components.DarkRealDevicePreview
@@ -149,53 +146,6 @@ private fun MatchRecordList(
         onDeleteClick = { onDeleteMatchRecord(record) },
         onMatchClick = onMatchClick,
       )
-    }
-  }
-}
-
-@Keep
-data class MatchRecordProperties(
-  val won: String,
-  val lost: String,
-  val draw: String,
-  val inProgress: String,
-  val lostColor: Color,
-  val winColor: Color,
-  val drawColor: Color,
-  val inProgressColor: Color,
-) {
-  companion object {
-    @Composable
-    fun rememberMatchRecordProperties(): MatchRecordProperties {
-      val won: String = stringResource(R.string.won)
-      val lost: String = stringResource(R.string.lost)
-      val draw: String = stringResource(R.string.draw)
-      val inProgress: String = stringResource(R.string.in_progress)
-      val lostColor = colorResource(android.R.color.holo_red_dark)
-      val winColor = colorResource(android.R.color.holo_green_dark)
-      val drawColor = colorResource(android.R.color.holo_blue_dark)
-      val inProgressColor = MaterialTheme.colorScheme.inverseSurface
-      return remember(
-        won,
-        lost,
-        draw,
-        inProgress,
-        lostColor,
-        winColor,
-        drawColor,
-        inProgressColor,
-      ) {
-        MatchRecordProperties(
-          won = won,
-          lost = lost,
-          draw = draw,
-          inProgress = inProgress,
-          lostColor = lostColor,
-          winColor = winColor,
-          drawColor = drawColor,
-          inProgressColor = inProgressColor,
-        )
-      }
     }
   }
 }

--- a/app/src/main/kotlin/io/github/raghavsatyadev/scus/compose/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/kotlin/io/github/raghavsatyadev/scus/compose/ui/dashboard/DashboardScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.colorResource
@@ -33,7 +34,6 @@ import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.constraintlayout.compose.Dimension
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import io.github.raghavsatyadev.scus.R
-import io.github.raghavsatyadev.scus.compose.ui.dashboard.MatchRecordProperties.Companion.CreateMatchRecordProperties
 import io.github.raghavsatyadev.support.compose.components.AdUI
 import io.github.raghavsatyadev.support.compose.components.AppToolBar
 import io.github.raghavsatyadev.support.compose.components.DarkRealDevicePreview
@@ -130,26 +130,25 @@ private fun MatchRecordList(
   onDeleteMatchRecord: (MatchRecord) -> Unit,
 ) {
 
-  CreateMatchRecordProperties { properties ->
-    LazyColumn(
-      userScrollEnabled = true,
-      modifier = modifier,
-      contentPadding = PaddingValues(vertical = 8.dp),
-    ) {
-      items(matchRecords, key = { it.matchRecordId }) { record ->
-        MatchRecordItem(
-          modifier =
-            Modifier.animateItem()
-              .padding(vertical = 8.dp, horizontal = 16.dp)
-              .fillMaxWidth()
-              .wrapContentHeight(),
-          matchRecord = record,
-          properties = properties,
-          onCopyClick = { onCopyMatchRecord(record) },
-          onDeleteClick = { onDeleteMatchRecord(record) },
-          onMatchClick = onMatchClick,
-        )
-      }
+  val properties = MatchRecordProperties.rememberMatchRecordProperties()
+  LazyColumn(
+    userScrollEnabled = true,
+    modifier = modifier,
+    contentPadding = PaddingValues(vertical = 8.dp),
+  ) {
+    items(matchRecords, key = { it.matchRecordId }) { record ->
+      MatchRecordItem(
+        modifier =
+          Modifier.animateItem()
+            .padding(vertical = 8.dp, horizontal = 16.dp)
+            .fillMaxWidth()
+            .wrapContentHeight(),
+        matchRecord = record,
+        properties = properties,
+        onCopyClick = { onCopyMatchRecord(record) },
+        onDeleteClick = { onDeleteMatchRecord(record) },
+        onMatchClick = onMatchClick,
+      )
     }
   }
 }
@@ -167,7 +166,7 @@ data class MatchRecordProperties(
 ) {
   companion object {
     @Composable
-    fun CreateMatchRecordProperties(onCreated: @Composable (MatchRecordProperties) -> Unit) {
+    fun rememberMatchRecordProperties(): MatchRecordProperties {
       val won: String = stringResource(R.string.won)
       val lost: String = stringResource(R.string.lost)
       val draw: String = stringResource(R.string.draw)
@@ -176,7 +175,16 @@ data class MatchRecordProperties(
       val winColor = colorResource(android.R.color.holo_green_dark)
       val drawColor = colorResource(android.R.color.holo_blue_dark)
       val inProgressColor = MaterialTheme.colorScheme.inverseSurface
-      onCreated(
+      return remember(
+        won,
+        lost,
+        draw,
+        inProgress,
+        lostColor,
+        winColor,
+        drawColor,
+        inProgressColor,
+      ) {
         MatchRecordProperties(
           won = won,
           lost = lost,
@@ -187,7 +195,7 @@ data class MatchRecordProperties(
           drawColor = drawColor,
           inProgressColor = inProgressColor,
         )
-      )
+      }
     }
   }
 }

--- a/app/src/main/kotlin/io/github/raghavsatyadev/scus/compose/ui/dashboard/MatchRecordItem.kt
+++ b/app/src/main/kotlin/io/github/raghavsatyadev/scus/compose/ui/dashboard/MatchRecordItem.kt
@@ -26,6 +26,7 @@ import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.constraintlayout.compose.Dimension
 import androidx.constraintlayout.compose.Visibility
 import io.github.raghavsatyadev.scus.R
+import io.github.raghavsatyadev.scus.compose.support.models.MatchRecordProperties
 import io.github.raghavsatyadev.support.compose.components.DarkPreview
 import io.github.raghavsatyadev.support.compose.components.LightPreview
 import io.github.raghavsatyadev.support.compose.theme.AppTheme

--- a/app/src/main/kotlin/io/github/raghavsatyadev/scus/compose/ui/dashboard/MatchRecordItem.kt
+++ b/app/src/main/kotlin/io/github/raghavsatyadev/scus/compose/ui/dashboard/MatchRecordItem.kt
@@ -42,17 +42,16 @@ import io.github.raghavsatyadev.support.models.db.match_record.MatchStatus
 fun MatchRecordItemPreview() {
   AppTheme {
     val matchRecord = getSampleMatchRecord(1)
-    MatchRecordProperties.CreateMatchRecordProperties { properties ->
-      MatchRecordItem(
-        matchRecord = matchRecord,
-        properties = properties,
-        onCopyClick = {},
-        onDeleteClick = {},
-        onMatchClick = {},
-        modifier =
-          Modifier.padding(vertical = 8.dp, horizontal = 16.dp).fillMaxWidth().wrapContentHeight(),
-      )
-    }
+    val properties = MatchRecordProperties.rememberMatchRecordProperties()
+    MatchRecordItem(
+      matchRecord = matchRecord,
+      properties = properties,
+      onCopyClick = {},
+      onDeleteClick = {},
+      onMatchClick = {},
+      modifier =
+        Modifier.padding(vertical = 8.dp, horizontal = 16.dp).fillMaxWidth().wrapContentHeight(),
+    )
   }
 }
 

--- a/app/src/main/kotlin/io/github/raghavsatyadev/scus/compose/ui/match_complete/MatchCompleteScreen.kt
+++ b/app/src/main/kotlin/io/github/raghavsatyadev/scus/compose/ui/match_complete/MatchCompleteScreen.kt
@@ -1,9 +1,10 @@
-@file:OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class)
+@file:OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 
 package io.github.raghavsatyadev.scus.compose.ui.match_complete
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -11,6 +12,8 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material3.ButtonGroupDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.ToggleButton
@@ -31,6 +34,7 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import io.github.raghavsatyadev.scus.R
 import io.github.raghavsatyadev.support.compose.components.AppToolBar
 import io.github.raghavsatyadev.support.models.BasicMatchUIDetails
+import io.github.raghavsatyadev.support.models.db.match_record.MatchRecord
 import io.github.raghavsatyadev.support.models.db.match_record.MatchRecordExtensions.toBasicMatchUIDetails
 
 @Composable
@@ -42,15 +46,28 @@ fun MatchCompleteScreen(
   LaunchedEffect(matchId) { viewModel.loadMatchRecord(matchId) }
 
   val matchRecord by viewModel.matchRecord.collectAsState()
-  var showTeam1 by remember { mutableStateOf(true) }
 
   val team1Details = remember(matchRecord) { matchRecord?.toBasicMatchUIDetails(true) }
   val team2Details = remember(matchRecord) { matchRecord?.toBasicMatchUIDetails(false) }
+
+  MatchCompleteUI(onBack, matchRecord, team1Details, team2Details)
+}
+
+@Composable
+private fun MatchCompleteUI(
+  onBack: () -> Unit,
+  matchRecord: MatchRecord?,
+  team1Details: BasicMatchUIDetails?,
+  team2Details: BasicMatchUIDetails?,
+) {
+  var showTeam1 by remember { mutableStateOf(true) }
   val details: BasicMatchUIDetails? = if (showTeam1) team1Details else team2Details
 
   Scaffold(
     modifier = Modifier.windowInsetsPadding(WindowInsets.systemBars),
-    topBar = { AppToolBar(title = stringResource(R.string.match_complete_title), onNavigateBack = onBack) },
+    topBar = {
+      AppToolBar(title = stringResource(R.string.match_complete_title), onNavigateBack = onBack)
+    },
   ) { padding ->
     ConstraintLayout(modifier = Modifier.fillMaxSize().padding(padding).padding(16.dp)) {
       val (
@@ -66,11 +83,12 @@ fun MatchCompleteScreen(
       details?.let { d ->
         Text(
           text = d.currentTeamName,
-          modifier = Modifier.constrainAs(txtTeam) {
-            top.linkTo(parent.top)
-            start.linkTo(parent.start)
-            end.linkTo(parent.end)
-          }
+          modifier =
+            Modifier.constrainAs(txtTeam) {
+              top.linkTo(parent.top)
+              start.linkTo(parent.start)
+              end.linkTo(parent.end)
+            },
         )
         matchRecord?.let { record ->
           val isBattingFirst = record.isTeam1BattingFirst
@@ -78,53 +96,59 @@ fun MatchCompleteScreen(
           if (showRequired) {
             Text(
               text = stringResource(R.string.required_runs_balls_at_end, d.requiredRunsBalls),
-              modifier = Modifier.constrainAs(txtRequired) {
-                start.linkTo(parent.start)
-                end.linkTo(parent.end)
-                top.linkTo(txtTeam.bottom, margin = 16.dp)
-              }
+              modifier =
+                Modifier.constrainAs(txtRequired) {
+                  start.linkTo(parent.start)
+                  end.linkTo(parent.end)
+                  top.linkTo(txtTeam.bottom, margin = 16.dp)
+                },
             )
             Text(
               text = stringResource(R.string.rrr_at_start, record.rrrAtSecondInningStart),
-              modifier = Modifier.constrainAs(txtRrr) {
-                start.linkTo(parent.start)
-                top.linkTo(txtRequired.bottom, margin = 8.dp)
-              }
+              modifier =
+                Modifier.constrainAs(txtRrr) {
+                  start.linkTo(parent.start)
+                  top.linkTo(txtRequired.bottom, margin = 8.dp)
+                },
             )
           } else {
             Text(
               text = stringResource(R.string.crr, d.currentCRR),
-              modifier = Modifier.constrainAs(txtCrr) {
-                start.linkTo(parent.start)
-                top.linkTo(txtTeam.bottom, margin = 16.dp)
-              }
+              modifier =
+                Modifier.constrainAs(txtCrr) {
+                  start.linkTo(parent.start)
+                  top.linkTo(txtTeam.bottom, margin = 16.dp)
+                },
             )
           }
         }
         Text(
           text = d.currentRunsAndWickets,
-          modifier = Modifier.constrainAs(txtRuns) {
-            top.linkTo(txtCrr.bottom, margin = 16.dp)
-            start.linkTo(parent.start)
-            end.linkTo(parent.end)
-          }
+          modifier =
+            Modifier.constrainAs(txtRuns) {
+              top.linkTo(txtCrr.bottom, margin = 16.dp)
+              start.linkTo(parent.start)
+              end.linkTo(parent.end)
+            },
         )
         Text(
           text = d.currentOvers,
-          modifier = Modifier.constrainAs(txtOvers) {
-            top.linkTo(txtRuns.bottom, margin = 8.dp)
-            start.linkTo(parent.start)
-          }
+          modifier =
+            Modifier.constrainAs(txtOvers) {
+              top.linkTo(txtRuns.bottom, margin = 8.dp)
+              start.linkTo(parent.start)
+            },
         )
       }
 
       FlowRow(
-        modifier = Modifier.constrainAs(toggleGroup) {
-          start.linkTo(parent.start)
-          end.linkTo(parent.end)
-          bottom.linkTo(parent.bottom)
-          width = Dimension.fillToConstraints
-        },
+        modifier =
+          Modifier.constrainAs(toggleGroup) {
+            start.linkTo(parent.start)
+            end.linkTo(parent.end)
+            bottom.linkTo(parent.bottom)
+            width = Dimension.fillToConstraints
+          },
         horizontalArrangement = Arrangement.spacedBy(ButtonGroupDefaults.ConnectedSpaceBetween),
       ) {
         ToggleButton(
@@ -133,7 +157,7 @@ fun MatchCompleteScreen(
           modifier = Modifier.weight(1f),
           shapes = ButtonGroupDefaults.connectedLeadingButtonShapes(),
         ) {
-          androidx.compose.foundation.layout.Spacer(Modifier.size(ToggleButtonDefaults.IconSpacing))
+          Spacer(Modifier.size(ToggleButtonDefaults.IconSpacing))
           Text(text = stringResource(R.string.team_1))
         }
         ToggleButton(
@@ -142,11 +166,10 @@ fun MatchCompleteScreen(
           modifier = Modifier.weight(1f),
           shapes = ButtonGroupDefaults.connectedTrailingButtonShapes(),
         ) {
-          androidx.compose.foundation.layout.Spacer(Modifier.size(ToggleButtonDefaults.IconSpacing))
+          Spacer(Modifier.size(ToggleButtonDefaults.IconSpacing))
           Text(text = stringResource(R.string.team_2))
         }
       }
     }
   }
 }
-

--- a/app/src/main/kotlin/io/github/raghavsatyadev/scus/compose/ui/match_complete/MatchCompleteScreen.kt
+++ b/app/src/main/kotlin/io/github/raghavsatyadev/scus/compose/ui/match_complete/MatchCompleteScreen.kt
@@ -1,0 +1,152 @@
+@file:OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class)
+
+package io.github.raghavsatyadev.scus.compose.ui.match_complete
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.material3.ButtonGroupDefaults
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.ToggleButton
+import androidx.compose.material3.ToggleButtonDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.constraintlayout.compose.ConstraintLayout
+import androidx.constraintlayout.compose.Dimension
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import io.github.raghavsatyadev.scus.R
+import io.github.raghavsatyadev.support.compose.components.AppToolBar
+import io.github.raghavsatyadev.support.models.BasicMatchUIDetails
+import io.github.raghavsatyadev.support.models.db.match_record.MatchRecordExtensions.toBasicMatchUIDetails
+
+@Composable
+fun MatchCompleteScreen(
+  matchId: String,
+  viewModel: MatchCompleteScreenViewModel = hiltViewModel(),
+  onBack: () -> Unit = {},
+) {
+  LaunchedEffect(matchId) { viewModel.loadMatchRecord(matchId) }
+
+  val matchRecord by viewModel.matchRecord.collectAsState()
+  var showTeam1 by remember { mutableStateOf(true) }
+
+  val team1Details = remember(matchRecord) { matchRecord?.toBasicMatchUIDetails(true) }
+  val team2Details = remember(matchRecord) { matchRecord?.toBasicMatchUIDetails(false) }
+  val details: BasicMatchUIDetails? = if (showTeam1) team1Details else team2Details
+
+  Scaffold(
+    modifier = Modifier.windowInsetsPadding(WindowInsets.systemBars),
+    topBar = { AppToolBar(title = stringResource(R.string.match_complete_title), onNavigateBack = onBack) },
+  ) { padding ->
+    ConstraintLayout(modifier = Modifier.fillMaxSize().padding(padding).padding(16.dp)) {
+      val (
+        txtTeam,
+        txtRequired,
+        txtRrr,
+        txtCrr,
+        txtRuns,
+        txtOvers,
+        toggleGroup,
+      ) = createRefs()
+
+      details?.let { d ->
+        Text(
+          text = d.currentTeamName,
+          modifier = Modifier.constrainAs(txtTeam) {
+            top.linkTo(parent.top)
+            start.linkTo(parent.start)
+            end.linkTo(parent.end)
+          }
+        )
+        matchRecord?.let { record ->
+          val isBattingFirst = record.isTeam1BattingFirst
+          val showRequired = (showTeam1 && !isBattingFirst) || (!showTeam1 && isBattingFirst)
+          if (showRequired) {
+            Text(
+              text = stringResource(R.string.required_runs_balls_at_end, d.requiredRunsBalls),
+              modifier = Modifier.constrainAs(txtRequired) {
+                start.linkTo(parent.start)
+                end.linkTo(parent.end)
+                top.linkTo(txtTeam.bottom, margin = 16.dp)
+              }
+            )
+            Text(
+              text = stringResource(R.string.rrr_at_start, record.rrrAtSecondInningStart),
+              modifier = Modifier.constrainAs(txtRrr) {
+                start.linkTo(parent.start)
+                top.linkTo(txtRequired.bottom, margin = 8.dp)
+              }
+            )
+          } else {
+            Text(
+              text = stringResource(R.string.crr, d.currentCRR),
+              modifier = Modifier.constrainAs(txtCrr) {
+                start.linkTo(parent.start)
+                top.linkTo(txtTeam.bottom, margin = 16.dp)
+              }
+            )
+          }
+        }
+        Text(
+          text = d.currentRunsAndWickets,
+          modifier = Modifier.constrainAs(txtRuns) {
+            top.linkTo(txtCrr.bottom, margin = 16.dp)
+            start.linkTo(parent.start)
+            end.linkTo(parent.end)
+          }
+        )
+        Text(
+          text = d.currentOvers,
+          modifier = Modifier.constrainAs(txtOvers) {
+            top.linkTo(txtRuns.bottom, margin = 8.dp)
+            start.linkTo(parent.start)
+          }
+        )
+      }
+
+      FlowRow(
+        modifier = Modifier.constrainAs(toggleGroup) {
+          start.linkTo(parent.start)
+          end.linkTo(parent.end)
+          bottom.linkTo(parent.bottom)
+          width = Dimension.fillToConstraints
+        },
+        horizontalArrangement = Arrangement.spacedBy(ButtonGroupDefaults.ConnectedSpaceBetween),
+      ) {
+        ToggleButton(
+          checked = showTeam1,
+          onCheckedChange = { showTeam1 = true },
+          modifier = Modifier.weight(1f),
+          shapes = ButtonGroupDefaults.connectedLeadingButtonShapes(),
+        ) {
+          androidx.compose.foundation.layout.Spacer(Modifier.size(ToggleButtonDefaults.IconSpacing))
+          Text(text = stringResource(R.string.team_1))
+        }
+        ToggleButton(
+          checked = !showTeam1,
+          onCheckedChange = { showTeam1 = false },
+          modifier = Modifier.weight(1f),
+          shapes = ButtonGroupDefaults.connectedTrailingButtonShapes(),
+        ) {
+          androidx.compose.foundation.layout.Spacer(Modifier.size(ToggleButtonDefaults.IconSpacing))
+          Text(text = stringResource(R.string.team_2))
+        }
+      }
+    }
+  }
+}
+

--- a/app/src/main/kotlin/io/github/raghavsatyadev/scus/compose/ui/match_complete/MatchCompleteScreenViewModel.kt
+++ b/app/src/main/kotlin/io/github/raghavsatyadev/scus/compose/ui/match_complete/MatchCompleteScreenViewModel.kt
@@ -1,0 +1,31 @@
+package io.github.raghavsatyadev.scus.compose.ui.match_complete
+
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import io.github.raghavsatyadev.support.compose.components.UiStateManager
+import io.github.raghavsatyadev.support.compose.core.CoreScreenViewModel
+import io.github.raghavsatyadev.support.models.db.match_record.MatchRecord
+import io.github.raghavsatyadev.support.models.db.match_record.MatchRecordComposeDataUtil
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+@HiltViewModel
+class MatchCompleteScreenViewModel @Inject constructor(
+  private val matchRecordDataUtil: MatchRecordComposeDataUtil,
+  uiStateManager: UiStateManager,
+) : CoreScreenViewModel(uiStateManager) {
+  private val _matchRecord = MutableStateFlow<MatchRecord?>(null)
+  val matchRecord = _matchRecord.asStateFlow()
+
+  fun loadMatchRecord(matchRecordId: String) {
+    viewModelScope.launch {
+      withContext(ioDispatcher) {
+        _matchRecord.emit(matchRecordDataUtil.getItem(matchRecordId))
+      }
+    }
+  }
+}
+

--- a/app/src/main/kotlin/io/github/raghavsatyadev/scus/compose/ui/match_record/MatchRecordScreen.kt
+++ b/app/src/main/kotlin/io/github/raghavsatyadev/scus/compose/ui/match_record/MatchRecordScreen.kt
@@ -1,4 +1,4 @@
-@file:OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class)
+@file:OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 
 package io.github.raghavsatyadev.scus.compose.ui.match_record
 
@@ -8,28 +8,29 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material3.Button
-import androidx.compose.material3.ExtendedFloatingActionButton
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.compose.ConstraintLayout
-import androidx.constraintlayout.compose.Dimension
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import io.github.raghavsatyadev.scus.R
 import io.github.raghavsatyadev.support.compose.components.AppToolBar
+import io.github.raghavsatyadev.support.compose.components.DarkRealDevicePreview
+import io.github.raghavsatyadev.support.compose.theme.AppTheme
 import io.github.raghavsatyadev.support.models.BasicMatchUIDetails
 import io.github.raghavsatyadev.support.models.db.match_record.MatchRecord
 import io.github.raghavsatyadev.support.models.db.match_record.MatchRecordExtensions.isMatchCompleted
+import io.github.raghavsatyadev.support.models.db.match_record.MatchRecordExtensions.toBasicMatchUIDetails
+import io.github.raghavsatyadev.support.models.db.match_record.TeamDetail
 
 @Composable
 fun MatchRecordScreen(
@@ -43,7 +44,7 @@ fun MatchRecordScreen(
 
   val recordState by viewModel.matchRecordEvent.collectAsState()
 
-  LaunchedEffect(recordState?.status) {
+  LaunchedEffect(recordState?.matchStatus) {
     if (recordState?.isMatchCompleted() == true) {
       onMatchCompleted()
     }
@@ -51,6 +52,16 @@ fun MatchRecordScreen(
 
   val record = recordState
 
+  MatchRecordUI(matchId, record, viewModel, onBack)
+}
+
+@Composable
+private fun MatchRecordUI(
+  matchId: String,
+  record: BasicMatchUIDetails?,
+  viewModel: MatchRecordScreenViewModel,
+  onBack: () -> Unit,
+) {
   Scaffold(
     modifier = Modifier.windowInsetsPadding(WindowInsets.systemBars),
     topBar = {
@@ -81,127 +92,176 @@ fun MatchRecordScreen(
       record?.let { details ->
         if (details.isFirstInningComplete) {
           Text(
-            text = stringResource(
-              R.string.required_runs_balls,
-              details.requiredRunsBalls
-            ),
-            modifier = Modifier.constrainAs(txtRequired) {
-              start.linkTo(parent.start)
-              end.linkTo(parent.end)
-              top.linkTo(parent.top)
-            }
+            text = stringResource(R.string.required_runs_balls, details.requiredRunsBalls),
+            modifier =
+              Modifier.constrainAs(txtRequired) {
+                start.linkTo(parent.start)
+                end.linkTo(parent.end)
+                top.linkTo(parent.top)
+              },
           )
           Text(
             text = stringResource(R.string.crr, details.currentCRR),
-            modifier = Modifier.constrainAs(txtCrr) {
-              start.linkTo(parent.start)
-              top.linkTo(txtRequired.bottom, margin = 8.dp)
-            }
+            modifier =
+              Modifier.constrainAs(txtCrr) {
+                start.linkTo(parent.start)
+                top.linkTo(txtRequired.bottom, margin = 8.dp)
+              },
           )
           Text(
             text = stringResource(R.string.rrr, details.currentRRR),
-            modifier = Modifier.constrainAs(txtRrr) {
-              end.linkTo(parent.end)
-              top.linkTo(txtRequired.bottom, margin = 8.dp)
-            }
+            modifier =
+              Modifier.constrainAs(txtRrr) {
+                end.linkTo(parent.end)
+                top.linkTo(txtRequired.bottom, margin = 8.dp)
+              },
           )
         } else {
           Button(
             onClick = { viewModel.endInning(matchId) },
-            modifier = Modifier.constrainAs(btnEndInning) {
-              start.linkTo(parent.start)
-              end.linkTo(parent.end)
-              top.linkTo(parent.top)
-            }
-          ) { Text(text = stringResource(R.string.end_inning)) }
+            modifier =
+              Modifier.constrainAs(btnEndInning) {
+                start.linkTo(parent.start)
+                end.linkTo(parent.end)
+                top.linkTo(parent.top)
+              },
+          ) {
+            Text(text = stringResource(R.string.end_inning))
+          }
         }
 
         Text(
           text = details.currentRunsAndWickets,
-          modifier = Modifier.constrainAs(txtRuns) {
-            start.linkTo(parent.start)
-            end.linkTo(parent.end)
-            top.linkTo(txtCrr.bottom, margin = 16.dp)
-          }
+          modifier =
+            Modifier.constrainAs(txtRuns) {
+              start.linkTo(parent.start)
+              end.linkTo(parent.end)
+              top.linkTo(txtCrr.bottom, margin = 16.dp)
+            },
         )
         Text(
           text = details.currentOvers,
-          modifier = Modifier.constrainAs(txtOvers) {
-            start.linkTo(parent.start)
-            top.linkTo(txtRuns.bottom, margin = 8.dp)
-          }
+          modifier =
+            Modifier.constrainAs(txtOvers) {
+              start.linkTo(parent.start)
+              top.linkTo(txtRuns.bottom, margin = 8.dp)
+            },
         )
         Button(
           onClick = {
             // simple dialog replacement: increment overs by 1 for demo
-            viewModel.editTotalOvers(matchId, details.totalOvers + 1)
+            // viewModel.editTotalOvers(matchId, details.currentOvers + 1)
           },
-          modifier = Modifier.constrainAs(btnEditOvers) {
-            start.linkTo(txtOvers.end, margin = 8.dp)
-            top.linkTo(txtOvers.top)
-          }
-        ) { Text(text = stringResource(R.string.edit_total_overs)) }
+          modifier =
+            Modifier.constrainAs(btnEditOvers) {
+              start.linkTo(txtOvers.end, margin = 8.dp)
+              top.linkTo(txtOvers.top)
+            },
+        ) {
+          Text(text = stringResource(R.string.edit_total_overs))
+        }
 
-        ExtendedFloatingActionButton(
+        Button(
+          shapes = ButtonDefaults.shapes(),
           onClick = { viewModel.setRun(matchId, 1, false) },
-          modifier = Modifier.constrainAs(btnMinusRun) {
-            start.linkTo(parent.start)
-            bottom.linkTo(btnAddRun.top, margin = 8.dp)
-          },
-          text = { Text("-") }
-        )
-        ExtendedFloatingActionButton(
+          modifier =
+            Modifier.constrainAs(btnMinusRun) {
+              start.linkTo(parent.start)
+              bottom.linkTo(btnAddRun.top, margin = 8.dp)
+            },
+        ) {
+          Text("-")
+        }
+        Button(
+          shapes = ButtonDefaults.shapes(),
           onClick = { viewModel.setRun(matchId, 1) },
-          modifier = Modifier.constrainAs(btnAddRun) {
-            start.linkTo(parent.start)
-            bottom.linkTo(parent.bottom)
-          },
-          text = { Text("+Run") }
-        )
-        ExtendedFloatingActionButton(
+          modifier =
+            Modifier.constrainAs(btnAddRun) {
+              start.linkTo(parent.start)
+              bottom.linkTo(parent.bottom)
+            },
+        ) {
+          Text("+Run")
+        }
+        Button(
+          shapes = ButtonDefaults.shapes(),
           onClick = { viewModel.setBall(matchId, 1, false) },
-          modifier = Modifier.constrainAs(btnMinusBall) {
-            end.linkTo(parent.end)
-            bottom.linkTo(btnAddBall.top, margin = 8.dp)
-          },
-          text = { Text("-") }
-        )
-        ExtendedFloatingActionButton(
+          modifier =
+            Modifier.constrainAs(btnMinusBall) {
+              end.linkTo(parent.end)
+              bottom.linkTo(btnAddBall.top, margin = 8.dp)
+            },
+        ) {
+          Text("-")
+        }
+        Button(
+          shapes = ButtonDefaults.shapes(),
           onClick = { viewModel.setBall(matchId, 1) },
-          modifier = Modifier.constrainAs(btnAddBall) {
-            end.linkTo(parent.end)
-            bottom.linkTo(parent.bottom)
-          },
-          text = { Text("+Ball") }
-        )
-        ExtendedFloatingActionButton(
+          modifier =
+            Modifier.constrainAs(btnAddBall) {
+              end.linkTo(parent.end)
+              bottom.linkTo(parent.bottom)
+            },
+        ) {
+          Text("+Ball")
+        }
+        Button(
+          shapes = ButtonDefaults.shapes(),
           onClick = { viewModel.setWicket(matchId, false) },
-          modifier = Modifier.constrainAs(btnMinusWicket) {
-            start.linkTo(btnAddRun.end, margin = 16.dp)
-            end.linkTo(btnAddBall.start, margin = 16.dp)
-            bottom.linkTo(btnAddRun.top, margin = 8.dp)
-          },
-          text = { Text("-") }
-        )
-        ExtendedFloatingActionButton(
+          modifier =
+            Modifier.constrainAs(btnMinusWicket) {
+              start.linkTo(btnAddRun.end, margin = 16.dp)
+              end.linkTo(btnAddBall.start, margin = 16.dp)
+              bottom.linkTo(btnAddRun.top, margin = 8.dp)
+            },
+        ) {
+          Text("-")
+        }
+        Button(
+          shapes = ButtonDefaults.shapes(),
           onClick = { viewModel.setWicket(matchId) },
-          modifier = Modifier.constrainAs(btnAddWicket) {
-            start.linkTo(btnAddRun.end, margin = 16.dp)
-            end.linkTo(btnAddBall.start, margin = 16.dp)
-            bottom.linkTo(btnAddBall.top, margin = 8.dp)
-          },
-          text = { Text("+W") }
-        )
+          modifier =
+            Modifier.constrainAs(btnAddWicket) {
+              start.linkTo(btnAddRun.end, margin = 16.dp)
+              end.linkTo(btnAddBall.start, margin = 16.dp)
+              bottom.linkTo(btnAddBall.top, margin = 8.dp)
+            },
+        ) {
+          Text("+W")
+        }
         Button(
           onClick = { viewModel.endMatch(matchId) },
-          modifier = Modifier.constrainAs(btnEndMatch) {
-            start.linkTo(parent.start)
-            end.linkTo(parent.end)
-            top.linkTo(txtOvers.bottom, margin = 16.dp)
-          }
-        ) { Text(text = stringResource(R.string.end_match)) }
+          modifier =
+            Modifier.constrainAs(btnEndMatch) {
+              start.linkTo(parent.start)
+              end.linkTo(parent.end)
+              top.linkTo(txtOvers.bottom, margin = 16.dp)
+            },
+        ) {
+          Text(text = stringResource(R.string.end_match))
+        }
       }
     }
   }
 }
 
+@DarkRealDevicePreview
+@Composable
+fun MatchRecordScreenPreview() {
+  AppTheme {
+    MatchRecordUI(
+      matchId = "match123",
+      record =
+        MatchRecord(
+            matchRecordId = "record123",
+            startDateTime = System.currentTimeMillis(),
+            team1Detail = TeamDetail(teamName = "Team A", runs = 150, wickets = 5, balls = 120),
+            team2Detail = TeamDetail(teamName = "Team B", runs = 100, wickets = 3, balls = 90),
+            ballsPerInning = 120,
+            matchAdminID = "admin123",
+          )
+          .toBasicMatchUIDetails(),
+      viewModel = hiltViewModel<MatchRecordScreenViewModel>(),
+    ) {}
+  }
+}

--- a/app/src/main/kotlin/io/github/raghavsatyadev/scus/compose/ui/match_record/MatchRecordScreen.kt
+++ b/app/src/main/kotlin/io/github/raghavsatyadev/scus/compose/ui/match_record/MatchRecordScreen.kt
@@ -1,0 +1,207 @@
+@file:OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class)
+
+package io.github.raghavsatyadev.scus.compose.ui.match_record
+
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExtendedFloatingActionButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.constraintlayout.compose.ConstraintLayout
+import androidx.constraintlayout.compose.Dimension
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import io.github.raghavsatyadev.scus.R
+import io.github.raghavsatyadev.support.compose.components.AppToolBar
+import io.github.raghavsatyadev.support.models.BasicMatchUIDetails
+import io.github.raghavsatyadev.support.models.db.match_record.MatchRecord
+import io.github.raghavsatyadev.support.models.db.match_record.MatchRecordExtensions.isMatchCompleted
+
+@Composable
+fun MatchRecordScreen(
+  matchId: String,
+  matchRecord: MatchRecord,
+  viewModel: MatchRecordScreenViewModel = hiltViewModel(),
+  onBack: () -> Unit = {},
+  onMatchCompleted: () -> Unit = {},
+) {
+  LaunchedEffect(matchRecord) { viewModel.loadMatchRecord(matchRecord) }
+
+  val recordState by viewModel.matchRecordEvent.collectAsState()
+
+  LaunchedEffect(recordState?.status) {
+    if (recordState?.isMatchCompleted() == true) {
+      onMatchCompleted()
+    }
+  }
+
+  val record = recordState
+
+  Scaffold(
+    modifier = Modifier.windowInsetsPadding(WindowInsets.systemBars),
+    topBar = {
+      val title =
+        record?.let { stringResource(R.string.team) + " " + it.currentTeamName }
+          ?: stringResource(R.string.match_record_title)
+      AppToolBar(title = title, onNavigateBack = onBack)
+    },
+  ) { padding ->
+    ConstraintLayout(modifier = Modifier.fillMaxSize().padding(padding).padding(16.dp)) {
+      val (
+        txtRequired,
+        txtCrr,
+        txtRrr,
+        txtRuns,
+        txtOvers,
+        btnEditOvers,
+        btnMinusRun,
+        btnAddRun,
+        btnMinusBall,
+        btnAddBall,
+        btnMinusWicket,
+        btnAddWicket,
+        btnEndInning,
+        btnEndMatch,
+      ) = createRefs()
+
+      record?.let { details ->
+        if (details.isFirstInningComplete) {
+          Text(
+            text = stringResource(
+              R.string.required_runs_balls,
+              details.requiredRunsBalls
+            ),
+            modifier = Modifier.constrainAs(txtRequired) {
+              start.linkTo(parent.start)
+              end.linkTo(parent.end)
+              top.linkTo(parent.top)
+            }
+          )
+          Text(
+            text = stringResource(R.string.crr, details.currentCRR),
+            modifier = Modifier.constrainAs(txtCrr) {
+              start.linkTo(parent.start)
+              top.linkTo(txtRequired.bottom, margin = 8.dp)
+            }
+          )
+          Text(
+            text = stringResource(R.string.rrr, details.currentRRR),
+            modifier = Modifier.constrainAs(txtRrr) {
+              end.linkTo(parent.end)
+              top.linkTo(txtRequired.bottom, margin = 8.dp)
+            }
+          )
+        } else {
+          Button(
+            onClick = { viewModel.endInning(matchId) },
+            modifier = Modifier.constrainAs(btnEndInning) {
+              start.linkTo(parent.start)
+              end.linkTo(parent.end)
+              top.linkTo(parent.top)
+            }
+          ) { Text(text = stringResource(R.string.end_inning)) }
+        }
+
+        Text(
+          text = details.currentRunsAndWickets,
+          modifier = Modifier.constrainAs(txtRuns) {
+            start.linkTo(parent.start)
+            end.linkTo(parent.end)
+            top.linkTo(txtCrr.bottom, margin = 16.dp)
+          }
+        )
+        Text(
+          text = details.currentOvers,
+          modifier = Modifier.constrainAs(txtOvers) {
+            start.linkTo(parent.start)
+            top.linkTo(txtRuns.bottom, margin = 8.dp)
+          }
+        )
+        Button(
+          onClick = {
+            // simple dialog replacement: increment overs by 1 for demo
+            viewModel.editTotalOvers(matchId, details.totalOvers + 1)
+          },
+          modifier = Modifier.constrainAs(btnEditOvers) {
+            start.linkTo(txtOvers.end, margin = 8.dp)
+            top.linkTo(txtOvers.top)
+          }
+        ) { Text(text = stringResource(R.string.edit_total_overs)) }
+
+        ExtendedFloatingActionButton(
+          onClick = { viewModel.setRun(matchId, 1, false) },
+          modifier = Modifier.constrainAs(btnMinusRun) {
+            start.linkTo(parent.start)
+            bottom.linkTo(btnAddRun.top, margin = 8.dp)
+          },
+          text = { Text("-") }
+        )
+        ExtendedFloatingActionButton(
+          onClick = { viewModel.setRun(matchId, 1) },
+          modifier = Modifier.constrainAs(btnAddRun) {
+            start.linkTo(parent.start)
+            bottom.linkTo(parent.bottom)
+          },
+          text = { Text("+Run") }
+        )
+        ExtendedFloatingActionButton(
+          onClick = { viewModel.setBall(matchId, 1, false) },
+          modifier = Modifier.constrainAs(btnMinusBall) {
+            end.linkTo(parent.end)
+            bottom.linkTo(btnAddBall.top, margin = 8.dp)
+          },
+          text = { Text("-") }
+        )
+        ExtendedFloatingActionButton(
+          onClick = { viewModel.setBall(matchId, 1) },
+          modifier = Modifier.constrainAs(btnAddBall) {
+            end.linkTo(parent.end)
+            bottom.linkTo(parent.bottom)
+          },
+          text = { Text("+Ball") }
+        )
+        ExtendedFloatingActionButton(
+          onClick = { viewModel.setWicket(matchId, false) },
+          modifier = Modifier.constrainAs(btnMinusWicket) {
+            start.linkTo(btnAddRun.end, margin = 16.dp)
+            end.linkTo(btnAddBall.start, margin = 16.dp)
+            bottom.linkTo(btnAddRun.top, margin = 8.dp)
+          },
+          text = { Text("-") }
+        )
+        ExtendedFloatingActionButton(
+          onClick = { viewModel.setWicket(matchId) },
+          modifier = Modifier.constrainAs(btnAddWicket) {
+            start.linkTo(btnAddRun.end, margin = 16.dp)
+            end.linkTo(btnAddBall.start, margin = 16.dp)
+            bottom.linkTo(btnAddBall.top, margin = 8.dp)
+          },
+          text = { Text("+W") }
+        )
+        Button(
+          onClick = { viewModel.endMatch(matchId) },
+          modifier = Modifier.constrainAs(btnEndMatch) {
+            start.linkTo(parent.start)
+            end.linkTo(parent.end)
+            top.linkTo(txtOvers.bottom, margin = 16.dp)
+          }
+        ) { Text(text = stringResource(R.string.end_match)) }
+      }
+    }
+  }
+}
+

--- a/app/src/main/kotlin/io/github/raghavsatyadev/scus/compose/ui/match_record/MatchRecordScreenViewModel.kt
+++ b/app/src/main/kotlin/io/github/raghavsatyadev/scus/compose/ui/match_record/MatchRecordScreenViewModel.kt
@@ -1,0 +1,183 @@
+package io.github.raghavsatyadev.scus.compose.ui.match_record
+
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import io.github.raghavsatyadev.support.compose.components.UiStateManager
+import io.github.raghavsatyadev.support.compose.core.CoreScreenViewModel
+import io.github.raghavsatyadev.support.models.BasicMatchUIDetails
+import io.github.raghavsatyadev.support.models.db.match_record.MatchRecord
+import io.github.raghavsatyadev.support.models.db.match_record.MatchRecordComposeDataUtil
+import io.github.raghavsatyadev.support.models.db.match_record.MatchRecordExtensions.getRRR
+import io.github.raghavsatyadev.support.models.db.match_record.MatchRecordExtensions.isTeam1CurrentlyBatting
+import io.github.raghavsatyadev.support.models.db.match_record.MatchRecordExtensions.toBasicMatchUIDetails
+import io.github.raghavsatyadev.support.models.db.match_record.MatchStatus
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+@HiltViewModel
+class MatchRecordScreenViewModel @Inject constructor(
+  private val matchRecordDataUtil: MatchRecordComposeDataUtil,
+  uiStateManager: UiStateManager,
+) : CoreScreenViewModel(uiStateManager) {
+  private val _matchRecordEvent = MutableStateFlow<BasicMatchUIDetails?>(null)
+  val matchRecordEvent = _matchRecordEvent.asStateFlow()
+
+  fun loadMatchRecord(matchRecord: MatchRecord) {
+    viewModelScope.launch {
+      matchRecordDataUtil.getItemLive(matchRecord.matchRecordId).collectLatest { value ->
+        _matchRecordEvent.emit(value.toBasicMatchUIDetails())
+      }
+    }
+  }
+
+  fun reset(matchRecordID: String, resetFull: Boolean = false) {
+    viewModelScope.launch {
+      withContext(ioDispatcher) {
+        val matchRecord = matchRecordDataUtil.getItem(matchRecordID)
+        if (resetFull) {
+          matchRecord.team1Detail.runs = 0
+          matchRecord.team1Detail.wickets = 0
+          matchRecord.team1Detail.balls = 0
+          matchRecord.team2Detail.runs = 0
+          matchRecord.team2Detail.wickets = 0
+          matchRecord.team2Detail.balls = 0
+          matchRecord.isFirstInningComplete = false
+        } else {
+          if (matchRecord.isTeam1CurrentlyBatting()) {
+            matchRecord.team1Detail.runs = 0
+            matchRecord.team1Detail.wickets = 0
+            matchRecord.team1Detail.balls = 0
+          } else {
+            matchRecord.team2Detail.runs = 0
+            matchRecord.team2Detail.wickets = 0
+            matchRecord.team2Detail.balls = 0
+          }
+        }
+        matchRecordDataUtil.update(matchRecord)
+      }
+    }
+  }
+
+  fun setRun(matchRecordID: String, runCount: Int, increase: Boolean = true) {
+    viewModelScope.launch {
+      withContext(ioDispatcher) {
+        val matchRecord = matchRecordDataUtil.getItem(matchRecordID)
+        val team1CurrentlyBatting = matchRecord.isTeam1CurrentlyBatting()
+        if (increase) {
+          if (team1CurrentlyBatting) {
+            matchRecord.team1Detail.runs += runCount
+          } else {
+            matchRecord.team2Detail.runs += runCount
+          }
+        } else {
+          if (team1CurrentlyBatting) {
+            if (matchRecord.team1Detail.runs - runCount < 0) return@withContext
+            matchRecord.team1Detail.runs -= runCount
+          } else {
+            if (matchRecord.team2Detail.runs - runCount < 0) return@withContext
+            matchRecord.team2Detail.runs -= runCount
+          }
+        }
+        matchRecordDataUtil.update(matchRecord)
+      }
+    }
+  }
+
+  fun setWicket(matchRecordID: String, increase: Boolean = true) {
+    viewModelScope.launch {
+      withContext(ioDispatcher) {
+        val matchRecord = matchRecordDataUtil.getItem(matchRecordID)
+        val team1CurrentlyBatting = matchRecord.isTeam1CurrentlyBatting()
+        if (increase) {
+          if (team1CurrentlyBatting) {
+            matchRecord.team1Detail.wickets++
+          } else {
+            matchRecord.team2Detail.wickets++
+          }
+        } else {
+          if (team1CurrentlyBatting) {
+            if (matchRecord.team1Detail.wickets - 1 < 0) return@withContext
+            matchRecord.team1Detail.wickets--
+          } else {
+            if (matchRecord.team2Detail.wickets - 1 < 0) return@withContext
+            matchRecord.team2Detail.wickets--
+          }
+        }
+        matchRecordDataUtil.update(matchRecord)
+      }
+    }
+  }
+
+  fun setBall(matchRecordID: String, ballCount: Int, increase: Boolean = true) {
+    viewModelScope.launch {
+      withContext(ioDispatcher) {
+        val matchRecord = matchRecordDataUtil.getItem(matchRecordID)
+        val team1CurrentlyBatting = matchRecord.isTeam1CurrentlyBatting()
+        if (increase) {
+          if (team1CurrentlyBatting) {
+            if (matchRecord.team1Detail.balls + ballCount > matchRecord.ballsPerInning) {
+              return@withContext
+            }
+            matchRecord.team1Detail.balls += ballCount
+          } else {
+            if (matchRecord.team2Detail.balls + ballCount > matchRecord.ballsPerInning) {
+              return@withContext
+            }
+            matchRecord.team2Detail.balls += ballCount
+          }
+        } else {
+          if (team1CurrentlyBatting) {
+            if (matchRecord.team1Detail.balls - ballCount < 0) return@withContext
+            matchRecord.team1Detail.balls -= ballCount
+          } else {
+            if (matchRecord.team2Detail.balls - ballCount < 0) return@withContext
+            matchRecord.team2Detail.balls -= ballCount
+          }
+        }
+        matchRecordDataUtil.update(matchRecord)
+      }
+    }
+  }
+
+  fun endInning(matchRecordID: String) {
+    viewModelScope.launch {
+      withContext(ioDispatcher) {
+        val matchRecord = matchRecordDataUtil.getItem(matchRecordID)
+        matchRecord.isFirstInningComplete = true
+        matchRecord.rrrAtSecondInningStart = matchRecord.getRRR()
+        matchRecordDataUtil.update(matchRecord)
+      }
+    }
+  }
+
+  fun endMatch(matchRecordID: String) {
+    viewModelScope.launch {
+      withContext(ioDispatcher) {
+        val matchRecord = matchRecordDataUtil.getItem(matchRecordID)
+        matchRecord.status =
+          when {
+            matchRecord.team1Detail.runs == matchRecord.team2Detail.runs -> MatchStatus.DRAW
+            matchRecord.team1Detail.runs > matchRecord.team2Detail.runs -> MatchStatus.TEAM_1_WON
+            else -> MatchStatus.TEAM_2_WON
+          }
+        matchRecord.endDateTime = System.currentTimeMillis()
+        matchRecordDataUtil.update(matchRecord)
+      }
+    }
+  }
+
+  fun editTotalOvers(matchRecordID: String, editedOvers: Int) {
+    viewModelScope.launch {
+      withContext(ioDispatcher) {
+        val matchRecord = matchRecordDataUtil.getItem(matchRecordID)
+        matchRecord.ballsPerInning = editedOvers * 6
+        matchRecordDataUtil.update(matchRecord)
+      }
+    }
+  }
+}
+


### PR DESCRIPTION
## Summary
- Port match record and match complete flows to Jetpack Compose
- Wire new screens into navigation with MatchComplete route
- Compose constraint-based layouts for scoreboard and controls

## Testing
- `gradle test --no-daemon --stacktrace --info` *(fails: build requires lengthy Android dependencies; see logs)*

------
https://chatgpt.com/codex/tasks/task_e_68ab3a9567388325a0486217f304aa83