### PR TITLE
Align match screens with existing XML UI

### DIFF
--- a/app/src/main/kotlin/io/github/raghavsatyadev/scus/compose/ui/match_complete/MatchCompleteScreen.kt
+++ b/app/src/main/kotlin/io/github/raghavsatyadev/scus/compose/ui/match_complete/MatchCompleteScreen.kt
@@ -111,12 +111,21 @@ private fun MatchCompleteUI(
                   top.linkTo(txtRequired.bottom, margin = 8.dp)
                 },
             )
+            Text(
+              text = stringResource(R.string.crr, d.currentCRR),
+              modifier =
+                Modifier.constrainAs(txtCrr) {
+                  end.linkTo(parent.end)
+                  top.linkTo(txtRequired.bottom, margin = 8.dp)
+                },
+            )
           } else {
             Text(
               text = stringResource(R.string.crr, d.currentCRR),
               modifier =
                 Modifier.constrainAs(txtCrr) {
                   start.linkTo(parent.start)
+                  end.linkTo(parent.end)
                   top.linkTo(txtTeam.bottom, margin = 16.dp)
                 },
             )
@@ -137,6 +146,7 @@ private fun MatchCompleteUI(
             Modifier.constrainAs(txtOvers) {
               top.linkTo(txtRuns.bottom, margin = 8.dp)
               start.linkTo(parent.start)
+              end.linkTo(parent.end)
             },
         )
       }

--- a/app/src/main/kotlin/io/github/raghavsatyadev/scus/compose/ui/match_record/MatchRecordScreen.kt
+++ b/app/src/main/kotlin/io/github/raghavsatyadev/scus/compose/ui/match_record/MatchRecordScreen.kt
@@ -11,6 +11,9 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.ExtendedFloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -18,6 +21,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.compose.ConstraintLayout
@@ -79,25 +83,38 @@ private fun MatchRecordUI(
         txtRuns,
         txtOvers,
         btnEditOvers,
-        btnMinusRun,
-        btnAddRun,
-        btnMinusBall,
-        btnAddBall,
+        labelWickets,
         btnMinusWicket,
         btnAddWicket,
+        labelOvers,
+        btnMinusBall,
+        btnAddBall,
+        labelRuns,
+        btnMinusRun,
+        btnAddRun,
         btnEndInning,
         btnEndMatch,
       ) = createRefs()
 
       record?.let { details ->
         if (details.isFirstInningComplete) {
+          Button(
+            onClick = { viewModel.endMatch(matchId) },
+            modifier =
+              Modifier.constrainAs(btnEndMatch) {
+                start.linkTo(parent.start)
+                end.linkTo(parent.end)
+                top.linkTo(parent.top)
+              },
+          ) { Text(text = stringResource(R.string.end_match)) }
+
           Text(
             text = stringResource(R.string.required_runs_balls, details.requiredRunsBalls),
             modifier =
               Modifier.constrainAs(txtRequired) {
                 start.linkTo(parent.start)
                 end.linkTo(parent.end)
-                top.linkTo(parent.top)
+                top.linkTo(btnEndMatch.bottom, margin = 16.dp)
               },
           )
           Text(
@@ -125,9 +142,17 @@ private fun MatchRecordUI(
                 end.linkTo(parent.end)
                 top.linkTo(parent.top)
               },
-          ) {
-            Text(text = stringResource(R.string.end_inning))
-          }
+          ) { Text(text = stringResource(R.string.end_inning)) }
+
+          Text(
+            text = stringResource(R.string.crr, details.currentCRR),
+            modifier =
+              Modifier.constrainAs(txtCrr) {
+                start.linkTo(parent.start)
+                end.linkTo(parent.end)
+                top.linkTo(btnEndInning.bottom, margin = 16.dp)
+              },
+          )
         }
 
         Text(
@@ -147,99 +172,111 @@ private fun MatchRecordUI(
               top.linkTo(txtRuns.bottom, margin = 8.dp)
             },
         )
-        Button(
-          onClick = {
-            // simple dialog replacement: increment overs by 1 for demo
-            // viewModel.editTotalOvers(matchId, details.currentOvers + 1)
-          },
+        IconButton(
+          onClick = { /* open overs edit dialog */ },
           modifier =
             Modifier.constrainAs(btnEditOvers) {
               start.linkTo(txtOvers.end, margin = 8.dp)
               top.linkTo(txtOvers.top)
             },
-        ) {
-          Text(text = stringResource(R.string.edit_total_overs))
-        }
+        ) { Icon(painterResource(R.drawable.ic_edit), null) }
 
-        Button(
-          shapes = ButtonDefaults.shapes(),
-          onClick = { viewModel.setRun(matchId, 1, false) },
+        // Wickets row
+        Text(
+          text = stringResource(R.string.wickets),
           modifier =
-            Modifier.constrainAs(btnMinusRun) {
-              start.linkTo(parent.start)
-              bottom.linkTo(btnAddRun.top, margin = 8.dp)
+            Modifier.constrainAs(labelWickets) {
+              start.linkTo(btnMinusWicket.end, margin = 8.dp)
+              end.linkTo(btnAddWicket.start, margin = 8.dp)
+              top.linkTo(txtOvers.bottom, margin = 16.dp)
             },
-        ) {
-          Text("-")
-        }
-        Button(
-          shapes = ButtonDefaults.shapes(),
-          onClick = { viewModel.setRun(matchId, 1) },
-          modifier =
-            Modifier.constrainAs(btnAddRun) {
-              start.linkTo(parent.start)
-              bottom.linkTo(parent.bottom)
-            },
-        ) {
-          Text("+Run")
-        }
-        Button(
-          shapes = ButtonDefaults.shapes(),
-          onClick = { viewModel.setBall(matchId, 1, false) },
-          modifier =
-            Modifier.constrainAs(btnMinusBall) {
-              end.linkTo(parent.end)
-              bottom.linkTo(btnAddBall.top, margin = 8.dp)
-            },
-        ) {
-          Text("-")
-        }
-        Button(
-          shapes = ButtonDefaults.shapes(),
-          onClick = { viewModel.setBall(matchId, 1) },
-          modifier =
-            Modifier.constrainAs(btnAddBall) {
-              end.linkTo(parent.end)
-              bottom.linkTo(parent.bottom)
-            },
-        ) {
-          Text("+Ball")
-        }
-        Button(
-          shapes = ButtonDefaults.shapes(),
+        )
+        ExtendedFloatingActionButton(
           onClick = { viewModel.setWicket(matchId, false) },
           modifier =
             Modifier.constrainAs(btnMinusWicket) {
-              start.linkTo(btnAddRun.end, margin = 16.dp)
-              end.linkTo(btnAddBall.start, margin = 16.dp)
-              bottom.linkTo(btnAddRun.top, margin = 8.dp)
+              top.linkTo(labelWickets.top)
+              bottom.linkTo(labelWickets.bottom)
+              start.linkTo(parent.start)
             },
-        ) {
-          Text("-")
-        }
-        Button(
-          shapes = ButtonDefaults.shapes(),
+          icon = { Icon(painterResource(R.drawable.ic_minus), contentDescription = null) },
+          text = {},
+        )
+        ExtendedFloatingActionButton(
           onClick = { viewModel.setWicket(matchId) },
           modifier =
             Modifier.constrainAs(btnAddWicket) {
-              start.linkTo(btnAddRun.end, margin = 16.dp)
-              end.linkTo(btnAddBall.start, margin = 16.dp)
-              bottom.linkTo(btnAddBall.top, margin = 8.dp)
-            },
-        ) {
-          Text("+W")
-        }
-        Button(
-          onClick = { viewModel.endMatch(matchId) },
-          modifier =
-            Modifier.constrainAs(btnEndMatch) {
-              start.linkTo(parent.start)
+              top.linkTo(labelWickets.top)
+              bottom.linkTo(labelWickets.bottom)
               end.linkTo(parent.end)
-              top.linkTo(txtOvers.bottom, margin = 16.dp)
             },
-        ) {
-          Text(text = stringResource(R.string.end_match))
-        }
+          icon = { Icon(painterResource(R.drawable.ic_add), contentDescription = null) },
+          text = {},
+        )
+
+        // Overs buttons
+        Text(
+          text = stringResource(R.string.overs),
+          modifier =
+            Modifier.constrainAs(labelOvers) {
+              start.linkTo(btnMinusBall.end, margin = 8.dp)
+              end.linkTo(btnAddBall.start, margin = 8.dp)
+              top.linkTo(labelWickets.bottom, margin = 24.dp)
+            },
+        )
+        ExtendedFloatingActionButton(
+          onClick = { viewModel.setBall(matchId, 1, false) },
+          modifier =
+            Modifier.constrainAs(btnMinusBall) {
+              top.linkTo(labelOvers.top)
+              bottom.linkTo(btnAddBall.top, margin = 8.dp)
+              start.linkTo(parent.start)
+            },
+          icon = { Icon(painterResource(R.drawable.ic_minus), contentDescription = null) },
+          text = {},
+        )
+        ExtendedFloatingActionButton(
+          onClick = { viewModel.setBall(matchId, 1) },
+          modifier =
+            Modifier.constrainAs(btnAddBall) {
+              start.linkTo(parent.start)
+              bottom.linkTo(parent.bottom)
+            },
+          icon = { Icon(painterResource(R.drawable.ic_add), contentDescription = null) },
+          text = {},
+        )
+
+        // Runs buttons
+        Text(
+          text = stringResource(R.string.runs),
+          modifier =
+            Modifier.constrainAs(labelRuns) {
+              start.linkTo(btnMinusRun.end, margin = 8.dp)
+              end.linkTo(btnAddRun.start, margin = 8.dp)
+              top.linkTo(labelOvers.bottom, margin = 24.dp)
+            },
+        )
+        ExtendedFloatingActionButton(
+          onClick = { viewModel.setRun(matchId, 1, false) },
+          modifier =
+            Modifier.constrainAs(btnMinusRun) {
+              top.linkTo(labelRuns.top)
+              bottom.linkTo(btnAddRun.top, margin = 8.dp)
+              end.linkTo(parent.end)
+            },
+          icon = { Icon(painterResource(R.drawable.ic_minus), contentDescription = null) },
+          text = {},
+        )
+        ExtendedFloatingActionButton(
+          onClick = { viewModel.setRun(matchId, 1) },
+          modifier =
+            Modifier.constrainAs(btnAddRun) {
+              end.linkTo(parent.end)
+              bottom.linkTo(parent.bottom)
+            },
+          icon = { Icon(painterResource(R.drawable.ic_add), contentDescription = null) },
+          text = {},
+        )
       }
     }
   }


### PR DESCRIPTION
## Summary
- Rework match record screen UI with CRR/RRR indicators and plus/minus controls for wickets, overs and runs
- Improve match complete screen to show required target with both RRR and CRR and center CRR when appropriate

## Testing
- `./gradlew test` *(fails: Gradle: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab75b608e8832589d8a8157829120b